### PR TITLE
get multi-hop neighbors bug

### DIFF
--- a/PaGraph/partition/dg.py
+++ b/PaGraph/partition/dg.py
@@ -22,8 +22,10 @@ def in_neighbors_hop(csc_adj, nid, hops):
     nids = []
     for depth in range(hops):
       neighs = nids[-1] if len(nids) != 0 else [nid]
+      in_neighs = []
       for n in neighs:
-        nids.append(in_neighbors(csc_adj, n))
+        in_neighs += in_neighbors(csc_adj, n)
+      nids.append(in_neighs)
     return np.unique(np.hstack(nids))
 
 


### PR DESCRIPTION
There is a small bug in `PaGraph/PaGraph/partition/dg.py`, there are no issues within two hops, but beyond two hops will result in a bug.

On line 26, all in_neighbors of neighs should be appended to nids list, not one of neighs.

https://github.com/zhiqi-0/PaGraph/blob/263fb13b84f27a8bd215bcde05b78cc3c4c17e7b/PaGraph/partition/dg.py#L18-L27
